### PR TITLE
加载默认的appsettings.json

### DIFF
--- a/src/Extensions/Senparc.Xncf.Swagger/Register.cs
+++ b/src/Extensions/Senparc.Xncf.Swagger/Register.cs
@@ -81,7 +81,9 @@ namespace Senparc.Xncf.Swagger
                 ConfigurationHelper.Configuration = configuration;
                 ConfigurationHelper.HostEnvironment = env;
                 ConfigurationHelper.WebHostEnvironment = webEnv;
-                ConfigurationHelper.SwaggerConfiguration = new ConfigurationBuilder().AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true).Build();
+                ConfigurationHelper.SwaggerConfiguration = new ConfigurationBuilder()
+                    .AddJsonFile($"appsettings.json")
+                    .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true).Build();
                 services.Configure<CustsomSwaggerOptions>(ConfigurationHelper.SwaggerConfiguration.GetSection("Swagger"));
 
                 ConfigurationHelper.CustsomSwaggerOptions = ConfigurationHelper.SwaggerConfiguration.GetSection("Swagger").Get<CustsomSwaggerOptions>() ?? new CustsomSwaggerOptions();


### PR DESCRIPTION
swagger 设置 添加从appsettings,json中读取配置. 
以解决默认项目没有appsettings.Development.json文件导致无法打开swagger问题.
