### PR TITLE
升级 UnitTestExtension，避免 Mock 对象过早访问 Mock.Object 对象，从而导致错误：Unable to c…

### DIFF
--- a/src/Basic/Senparc.Ncf.UnitTestExtension/BaseNcfUnitTest.cs
+++ b/src/Basic/Senparc.Ncf.UnitTestExtension/BaseNcfUnitTest.cs
@@ -52,7 +52,7 @@ namespace Senparc.Ncf.UnitTestExtension
         /// </summary>  
         /// <typeparam name="T">实体类型</typeparam>  
         /// <returns>仓储实例</returns>  
-        public (IClientRepositoryBase<T> Repository, Mock<IClientRepositoryBase<T>> MockRepository, List<T> DataList) GetRespository<T, TKey>() where T : EntityBase<TKey>
+        public (Mock<IClientRepositoryBase<T>> MockRepository, List<T> DataList) GetRespository<T, TKey>() where T : EntityBase<TKey>
         {
             var repo = GetRespository<T>();
 
@@ -95,7 +95,7 @@ namespace Senparc.Ncf.UnitTestExtension
         /// </summary>  
         /// <typeparam name="T">实体类型</typeparam>  
         /// <returns>仓储实例</returns>  
-        public (IClientRepositoryBase<T> Repository, Mock<IClientRepositoryBase<T>> MockRepository, List<T> DataList) GetRespository<T>() where T : EntityBase
+        public (Mock<IClientRepositoryBase<T>> MockRepository, List<T> DataList) GetRespository<T>() where T : EntityBase
         {
             TryInitSeedData<T>();
 
@@ -193,7 +193,14 @@ namespace Senparc.Ncf.UnitTestExtension
                     return Task.FromResult(dataList.Count(func));
                 });
 
-            return (Repository: mockRepository.Object, MockRepository: mockRepository, DataList: dataList);
+            return (MockRepository: mockRepository, DataList: dataList);
+        }
+
+        public Mock<TInterface> CreateMockForExtendedInterface<TInterface, TBase>(Mock<TBase> baseMock)
+            where TInterface : class, TBase
+            where TBase : class
+        {
+            return baseMock.As<TInterface>();
         }
     }
 }

--- a/src/Basic/Senparc.Ncf.UnitTestExtension/Senparc.Ncf.UnitTestExtension.csproj
+++ b/src/Basic/Senparc.Ncf.UnitTestExtension/Senparc.Ncf.UnitTestExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>0.1.1-preview1</Version>
+		<Version>0.1.1.2-preview1</Version>
 		<AssemblyName>Senparc.Ncf.UnitTestExtension</AssemblyName>
 		<RootNamespace>Senparc.Ncf.UnitTestExtension</RootNamespace>
 		<GeneratePackageOnBuild Condition=" '$(Configuration)' == 'Release' ">true</GeneratePackageOnBuild>


### PR DESCRIPTION
…reate instance of class Senparc.Areas.Admin.Domain.Tests.AdminUserInfoServiceTests. Error: System.InvalidOperationException: Mock type has already been initialized by accessing its Object property. Adding interfaces must be done before that..