### PR TITLE
Add multilingual support for NCF Installer resources

### DIFF
--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Areas/Admin/Pages/Login.cshtml
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Areas/Admin/Pages/Login.cshtml
@@ -2,12 +2,14 @@
 @model Senparc.Areas.Admin.Areas.Admin.Pages.LoginModel
 @{
     Layout = null;
+    var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
 }
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Senparc.Areas.Admin.AdminResource> AR
 <!DOCTYPE html>
-<html>
+<html lang="@currentCulture">
 <head>
     <meta charset="utf-8" />
-    <title>登录 NCF 管理后台</title>
+    <title>@AR["Admin.Title"]</title>
     <meta name="description" content="@ViewBag.Description" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,25 +26,36 @@
 </head>
 <body>
     <div class="content" id="app">
+        <div style="position: absolute; top: 18px; right: 18px; z-index: 10; background: rgba(255,255,255,.9); border-radius: 6px; padding: 6px 10px;">
+            <label for="ncf-login-lang" style="font-size: 12px; color: #606266; margin-right: 6px;">@AR["Admin.Language.SelectLanguage"]</label>
+            <select id="ncf-login-lang" onchange="ncfSwitchLanguage(this.value)">
+                <option value="zh-CN" selected="@(currentCulture == "zh-CN" ? "selected" : null)">简体中文</option>
+                <option value="en" selected="@(currentCulture.StartsWith("en") ? "selected" : null)">English</option>
+                <option value="ja" selected="@(currentCulture.StartsWith("ja") ? "selected" : null)">日本語</option>
+                <option value="fr" selected="@(currentCulture.StartsWith("fr") ? "selected" : null)">Français</option>
+                <option value="es" selected="@(currentCulture.StartsWith("es") ? "selected" : null)">Español</option>
+                <option value="ru" selected="@(currentCulture.StartsWith("ru") ? "selected" : null)">Русский</option>
+            </select>
+        </div>
         <div class="login-container animated fadeIn logoBox ">
             <div class="login-inner-box">
                 <span class="logoImg">
                     <img src="~/images/logo-login-ncf.png" width="173" />
                 </span>
                 <div class="loginbox bg-white logoBg">
-                    <div class="loginbox-title">管理员登录</div>
+                    <div class="loginbox-title">@AR["Admin.Login.Title"]</div>
                     <div class="loginbox-textbox">
                         <el-form :model="ruleForm" status-icon :rules="rules" ref="ruleForm" class="demo-ruleForm">
                             <el-form-item prop="user">
-                                <el-input v-model.number="ruleForm.user" placeholder="请输入用户名"></el-input>
+                                <el-input v-model.number="ruleForm.user" placeholder="@AR["Admin.Login.UsernamePlaceholder"]"></el-input>
                             </el-form-item>
                             <el-form-item prop="tenant" v-if="enableMultiTenant">
-                                <el-input v-model="ruleForm.tenant" placeholder="请输入租户名称"></el-input>
+                                <el-input v-model="ruleForm.tenant" placeholder="@AR["Admin.Login.TenantPlaceholder"]"></el-input>
                             </el-form-item>
                             <el-form-item prop="pass">
-                                <el-input type="password" v-model="ruleForm.pass" placeholder="请输入密码" autocomplete="off"></el-input>
+                                <el-input type="password" v-model="ruleForm.pass" placeholder="@AR["Admin.Login.PasswordPlaceholder"]" autocomplete="off"></el-input>
                             </el-form-item>
-                            <el-button :loading="loading" style="width: 100%;" type="primary" @@click="submitForm('ruleForm')">登录</el-button>
+                            <el-button :loading="loading" style="width: 100%;" type="primary" @@click="submitForm('ruleForm')">@AR["Admin.Login.Submit"]</el-button>
                         </el-form>
                     </div>
                 </div>
@@ -57,6 +70,19 @@
     <script src="~/lib/vue/vue.js"></script>
     <script src="~/lib/element-ui_2.13.2/element.js"></script>
     <script src="~/lib/axios/axios.min.js"></script>
+    <script>
+        window.ncfLoginI18n = {
+            usernameRequired: '@AR["Admin.Login.Error.UsernameRequired"]',
+            passwordRequired: '@AR["Admin.Login.Error.PasswordRequired"]',
+            loginFailed: 'Login failed',
+            loginRetry: 'Login failed, please try again'
+        };
+
+        function ncfSwitchLanguage(culture) {
+            var returnUrl = window.location.pathname + window.location.search;
+            window.location.href = '/api/Language/Set?culture=' + encodeURIComponent(culture) + '&returnUrl=' + encodeURIComponent(returnUrl);
+        }
+    </script>
     <!--js-->
     <script src="~/js/Admin/axios.js"></script>
     <script src="~/js/Admin/Pages/LogIn/index.js" asp-append-version="true"></script>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Areas/Admin/Pages/Shared/_Layout_Vue.cshtml
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Areas/Admin/Pages/Shared/_Layout_Vue.cshtml
@@ -1,10 +1,12 @@
 ﻿@model Senparc.Ncf.AreaBase.Admin.IAdminPageModelBase
 @{
     var thisYear = DateTime.Now.Year;
+    var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
 }
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Senparc.Areas.Admin.AdminResource> AR
 
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="@currentCulture">
 <head>
     <meta charset="utf-8" />
     <title>@ViewData["Title"]</title>
@@ -54,18 +56,29 @@
                         @*面包屑*@
                         <div class="header-breadcrumb">
                             <el-breadcrumb separator="/">
-                                <el-breadcrumb-item><a href="/Admin/Index">首页</a></el-breadcrumb-item>
+                                <el-breadcrumb-item><a href="/Admin/Index">@AR["Admin.Nav.Home"]</a></el-breadcrumb-item>
                                 @RenderSection("breadcrumbs", false)
                             </el-breadcrumb>
                         </div>
+                        <div class="header-language">
+                            <label for="ncf-lang" class="header-language-label">@AR["Admin.Language.SelectLanguage"]</label>
+                            <select id="ncf-lang" class="header-language-select" onchange="ncfSwitchLanguage(this.value)">
+                                <option value="zh-CN" selected="@(currentCulture == "zh-CN" ? "selected" : null)">简体中文</option>
+                                <option value="en" selected="@(currentCulture.StartsWith("en") ? "selected" : null)">English</option>
+                                <option value="ja" selected="@(currentCulture.StartsWith("ja") ? "selected" : null)">日本語</option>
+                                <option value="fr" selected="@(currentCulture.StartsWith("fr") ? "selected" : null)">Français</option>
+                                <option value="es" selected="@(currentCulture.StartsWith("es") ? "selected" : null)">Español</option>
+                                <option value="ru" selected="@(currentCulture.StartsWith("ru") ? "selected" : null)">Русский</option>
+                            </select>
+                        </div>
                         @*退出*@
                         <div class="header-logout">
-                            <el-tooltip class="item" effect="dark" content="退出登录" placement="left">
-                                <el-popconfirm confirmButtonText='退出'
-                                               cancelButtonText='不用了'
+                            <el-tooltip class="item" effect="dark" content="@AR["Admin.Logout.Title"]" placement="left">
+                                <el-popconfirm confirmButtonText='@AR["Admin.Logout.Yes"]'
+                                               cancelButtonText='@AR["Admin.Logout.No"]'
                                                icon="el-icon-info"
                                                iconColor="red"
-                                               title="确定退出吗？"
+                                               title="@AR["Admin.Logout.Confirm"]"
                                                @@on-Confirm="loginout">
                                     <i slot="reference" style="cursor:pointer;" class="fa fa-sign-out" aria-hidden="true"></i>
                                 </el-popconfirm>
@@ -98,6 +111,12 @@
     <script src="~/js/Admin/navMenu.js"></script>
     <script src="~/js/Admin/vuePermission.js"></script>
     <script src="~/js/Admin/Pages/Components/Components.js"></script>
+    <script>
+        function ncfSwitchLanguage(culture) {
+            var returnUrl = window.location.pathname + window.location.search;
+            window.location.href = '/api/Language/Set?culture=' + encodeURIComponent(culture) + '&returnUrl=' + encodeURIComponent(returnUrl);
+        }
+    </script>
     <!--页面js-->
     @*<script src="~/js/Admin/Pages/Index/Index.js"></script>*@
     @RenderSection("scripts", false)

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.cs
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.cs
@@ -1,0 +1,17 @@
+namespace Senparc.Areas.Admin
+{
+    /// <summary>
+    /// Marker class for Admin module localization resources.
+    /// Resource files are stored in Resources/AdminResource.{culture}.resx
+    ///
+    /// Usage in Razor views: @inject IStringLocalizer&lt;AdminResource&gt; AR
+    /// Usage in code:        IStringLocalizer&lt;AdminResource&gt; localizer (via DI)
+    ///
+    /// Supported cultures: zh-CN (default), en, ja, fr, es, ru
+    /// To add a new language: copy AdminResource.en.resx, rename to AdminResource.{culture}.resx,
+    /// translate the values, and add the culture code to NcfLocalizationOptions.SupportedCultures.
+    /// </summary>
+    public class AdminResource
+    {
+    }
+}

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.en.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.en.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>NCF Admin Panel</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>Logout</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>Are you sure you want to logout?</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>Logout</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>Admin Login</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>Tenant Name</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>Please enter username</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>Please enter password</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>Please enter tenant name</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>Username is required</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>Password is required</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>Select Language</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.es.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.es.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>Panel de administración NCF</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>Inicio</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>¿Está seguro de que desea cerrar sesión?</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>Inicio de sesión</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>Nombre del inquilino</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>Iniciar sesión</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>Ingrese el nombre de usuario</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>Ingrese la contraseña</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>Ingrese el nombre del inquilino</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>El nombre de usuario es requerido</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>Se requiere contraseña</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>Seleccionar idioma</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.fr.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.fr.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>Panneau d'administration NCF</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>Accueil</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>Déconnexion</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir vous déconnecter?</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>Déconnexion</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>Connexion administrateur</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>Nom du locataire</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>Entrez le nom d'utilisateur</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>Entrez le mot de passe</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>Entrez le nom du locataire</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>Le nom d'utilisateur est requis</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>Le mot de passe est requis</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>Sélectionner la langue</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.ja.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.ja.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>NCF 管理パネル</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>ホーム</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>ログアウト</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>ログアウトしますか？</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>ログアウト</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>管理者ログイン</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>ユーザー名</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>パスワード</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>テナント名</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>ログイン</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>ユーザー名を入力してください</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>パスワードを入力してください</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>テナント名を入力してください</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>ユーザー名を入力してください</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>パスワードを入力してください</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>言語選択</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>NCF 管理后台</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>首页</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>退出登录</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>确定退出吗？</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>不用了</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>管理员登录</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>用户名</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>租户名称</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>请输入用户名</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>请输入密码</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>请输入租户名称</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>请输入用户名</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>请输入密码</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>选择语言</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.ru.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.ru.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>Панель администратора NCF</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>Главная</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>Выйти</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>Вы уверены, что хотите выйти?</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>Выйти</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>Вход администратора</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>Название тенанта</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>Войти</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>Введите имя пользователя</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>Введите пароль</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>Введите название тенанта</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>Введите имя пользователя</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>Введите пароль</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>Выбор языка</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.zh-CN.resx
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/Resources/AdminResource.zh-CN.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Admin.Title" xml:space="preserve">
+    <value>NCF 管理后台</value>
+  </data>
+  <data name="Admin.Nav.Home" xml:space="preserve">
+    <value>首页</value>
+  </data>
+  <data name="Admin.Logout.Title" xml:space="preserve">
+    <value>退出登录</value>
+  </data>
+  <data name="Admin.Logout.Confirm" xml:space="preserve">
+    <value>确定退出吗？</value>
+  </data>
+  <data name="Admin.Logout.Yes" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="Admin.Logout.No" xml:space="preserve">
+    <value>不用了</value>
+  </data>
+  <data name="Admin.Login.Title" xml:space="preserve">
+    <value>管理员登录</value>
+  </data>
+  <data name="Admin.Login.Username" xml:space="preserve">
+    <value>用户名</value>
+  </data>
+  <data name="Admin.Login.Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="Admin.Login.Tenant" xml:space="preserve">
+    <value>租户名称</value>
+  </data>
+  <data name="Admin.Login.Submit" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="Admin.Login.UsernamePlaceholder" xml:space="preserve">
+    <value>请输入用户名</value>
+  </data>
+  <data name="Admin.Login.PasswordPlaceholder" xml:space="preserve">
+    <value>请输入密码</value>
+  </data>
+  <data name="Admin.Login.TenantPlaceholder" xml:space="preserve">
+    <value>请输入租户名称</value>
+  </data>
+  <data name="Admin.Login.Error.UsernameRequired" xml:space="preserve">
+    <value>请输入用户名</value>
+  </data>
+  <data name="Admin.Login.Error.PasswordRequired" xml:space="preserve">
+    <value>请输入密码</value>
+  </data>
+  <data name="Admin.Language.SelectLanguage" xml:space="preserve">
+    <value>选择语言</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/wwwroot/css/Admin/Shared/layout.css
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/wwwroot/css/Admin/Shared/layout.css
@@ -134,6 +134,31 @@ li {
     line-height: 60px;
 }
 
+.header-language {
+    height: 100%;
+    float: right;
+    line-height: 60px;
+    margin-right: 18px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.header-language-label {
+    font-size: 12px;
+    color: #606266;
+}
+
+.header-language-select {
+    border: 1px solid #dcdfe6;
+    border-radius: 4px;
+    font-size: 12px;
+    color: #303133;
+    padding: 2px 8px;
+    height: 28px;
+    background: #fff;
+}
+
 
 
 /*分页*/

--- a/tools/NcfSimulatedSite/Senparc.Areas.Admin/wwwroot/js/Admin/Pages/LogIn/Index.js
+++ b/tools/NcfSimulatedSite/Senparc.Areas.Admin/wwwroot/js/Admin/Pages/LogIn/Index.js
@@ -1,13 +1,13 @@
 ﻿var validatePass = (rule, value, callback) => {
     if (value === '') {
-        callback(new Error('请输入密码'));
+        callback(new Error((window.ncfLoginI18n && window.ncfLoginI18n.passwordRequired) || 'Password is required'));
     } else {
         callback();
     }
 };
 var validateUser = (rule, value, callback) => {
     if (value === '') {
-        callback(new Error('请输入用户名'));
+        callback(new Error((window.ncfLoginI18n && window.ncfLoginI18n.usernameRequired) || 'Username is required'));
     } else {
         callback();
     }
@@ -67,11 +67,11 @@ var app = new Vue({
                             const url = this.resizeUrl().ReturnUrl;
                             window.location.href = url ? unescape(url) : '/Admin/index';
                         } else {
-                            this.$message.error(res.data.message || '登录失败');
+                            this.$message.error(res.data.message || ((window.ncfLoginI18n && window.ncfLoginI18n.loginFailed) || 'Login failed'));
                             this.loading = false;
                         }
                     }).catch(error => {
-                        this.$message.error('登录失败，请重试');
+                        this.$message.error((window.ncfLoginI18n && window.ncfLoginI18n.loginRetry) || 'Login failed, please try again');
                         this.loading = false;
                     });
                 } else {

--- a/tools/NcfSimulatedSite/Senparc.Web/Controllers/LanguageController.cs
+++ b/tools/NcfSimulatedSite/Senparc.Web/Controllers/LanguageController.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Senparc.Web.Controllers
+{
+    /// <summary>
+    /// Language/Culture switcher controller.
+    /// Sets the culture cookie that ASP.NET Core's CookieRequestCultureProvider reads on every request.
+    /// The cookie persists the selection in the browser for 1 year.
+    ///
+    /// Endpoint: GET /api/Language/Set?culture=en&amp;returnUrl=/Admin
+    /// </summary>
+    [Route("api/[controller]")]
+    [ApiController]
+    public class LanguageController : ControllerBase
+    {
+        /// <summary>
+        /// All cultures supported by the application.
+        /// When adding a new language, also add the culture code here and create the
+        /// corresponding *.resx files in Resources/ for each module.
+        /// </summary>
+        public static readonly string[] SupportedCultures =
+            new[] { "zh-CN", "en", "ja", "fr", "es", "ru" };
+
+        /// <summary>
+        /// Sets the language preference cookie and redirects to the return URL.
+        /// </summary>
+        /// <param name="culture">Target culture code, e.g. "en", "zh-CN", "ja"</param>
+        /// <param name="returnUrl">URL to redirect to after switching. Defaults to "/"</param>
+        [HttpGet("Set")]
+        public IActionResult Set(string culture, string returnUrl = "/")
+        {
+            // Validate culture to prevent injection; fall back to default if unknown
+            if (string.IsNullOrWhiteSpace(culture) || !Array.Exists(SupportedCultures, c => c == culture))
+            {
+                culture = SupportedCultures[0]; // zh-CN
+            }
+
+            // Set the culture cookie (name matches CookieRequestCultureProvider.DefaultCookieName)
+            Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+                new CookieOptions
+                {
+                    MaxAge = TimeSpan.FromDays(365),
+                    IsEssential = true,      // GDPR: mark as essential so consent isn't required for functionality
+                    SameSite = SameSiteMode.Lax
+                }
+            );
+
+            // Validate returnUrl to prevent open-redirect attacks
+            if (!Url.IsLocalUrl(returnUrl))
+            {
+                returnUrl = "/";
+            }
+
+            return LocalRedirect(returnUrl);
+        }
+    }
+}

--- a/tools/NcfSimulatedSite/Senparc.Web/Program.cs
+++ b/tools/NcfSimulatedSite/Senparc.Web/Program.cs
@@ -1,4 +1,4 @@
-﻿//以下数据库模块的命名空间根据需要添加或删除
+//以下数据库模块的命名空间根据需要添加或删除
 //using Senparc.Ncf.Database.MySql;         //使用需要引用包： Senparc.Ncf.Database.MySql
 //using Senparc.Ncf.Database.Sqlite;        //使用需要引用包： Senparc.Ncf.Database.Sqlite
 //using Senparc.Ncf.Database.PostgreSQL;    //使用需要引用包： Senparc.Ncf.Database.PostgreSQL
@@ -10,6 +10,9 @@ using Senparc.CO2NET.HttpUtility;
 using Senparc.CO2NET.WebApi;
 using Senparc.Ncf.Database.SqlServer;
 using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Localization;
+using Senparc.Web.Controllers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,12 +30,20 @@ builder.Services.AddDaprClient();
 
 var app = builder.Build();
 
-//app.MapDefaultEndpoints();
-
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
 }
+
+// Configure request localization (cookie first, then query/header providers)
+var supportedCultures = LanguageController.SupportedCultures;
+var localizationOptions = new RequestLocalizationOptions()
+    .SetDefaultCulture(supportedCultures[0])
+    .AddSupportedCultures(supportedCultures)
+    .AddSupportedUICultures(supportedCultures)
+    .AddInitialRequestCultureProvider(new CookieRequestCultureProvider());
+
+app.UseRequestLocalization(localizationOptions);
 
 //Use NCF（必须）
 app.UseNcf<BySettingDatabaseConfiguration>();

--- a/tools/NcfSimulatedSite/Senparc.Web/Register.cs
+++ b/tools/NcfSimulatedSite/Senparc.Web/Register.cs
@@ -9,6 +9,7 @@ using Senparc.Ncf.Core.Models;
 using Senparc.Ncf.XncfBase;
 using Senparc.Xncf.AreasBase;
 using Senparc.Ncf.Core.EventBus;
+using Senparc.Web.Controllers;
 
 namespace Senparc.Web
 {
@@ -22,6 +23,10 @@ namespace Senparc.Web
         public static void AddNcf(this WebApplicationBuilder builder)
         {
             StartTime = SystemTime.Now.DateTime;
+
+            // Localization baseline for all modules (Web/Admin/Installer/XNCF).
+            // Use type-based lookup without ResourcesPath override to match embedded resource names.
+            builder.Services.AddLocalization();
 
             //激活 Xncf 扩展引擎（必须）
             var logMsg = builder.StartWebEngine(new[] { "Senparc.Areas.Admin"});

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.cs
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.cs
@@ -1,0 +1,15 @@
+namespace Senparc.Web
+{
+    /// <summary>
+    /// Marker class for shared localization resources.
+    /// Resource files are stored in Resources/SharedResource.{culture}.resx
+    /// 
+    /// Usage in views: @inject IStringLocalizer&lt;SharedResource&gt; SR
+    /// Usage in code:  IStringLocalizer&lt;SharedResource&gt; localizer (via DI)
+    /// 
+    /// Supported cultures: zh-CN (default), en, ja, fr, es, ru
+    /// </summary>
+    public class SharedResource
+    {
+    }
+}

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.en.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.en.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Language.SelectLanguage" xml:space="preserve">
+    <value>Select Language</value>
+  </data>
+  <data name="Language.zh-CN" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Language.en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.ja" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Language.fr" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Language.es" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Language.ru" xml:space="preserve">
+    <value>Русский</value>
+  </data>
+  <data name="Button.Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Button.Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Button.Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Button.Edit" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="Button.Search" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="Button.Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="Button.Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Button.Back" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="Button.Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="Message.Success" xml:space="preserve">
+    <value>Success</value>
+  </data>
+  <data name="Message.Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Message.Warning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="Message.Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
+  <data name="Message.NoData" xml:space="preserve">
+    <value>No Data</value>
+  </data>
+  <data name="Message.ConfirmDelete" xml:space="preserve">
+    <value>Confirm delete?</value>
+  </data>
+  <data name="Footer.PoweredBy" xml:space="preserve">
+    <value>Powered by:</value>
+  </data>
+  <data name="Footer.Copyright" xml:space="preserve">
+    <value>Senparc Network Technology Co., Ltd. All Rights Reserved</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.es.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.es.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Language.SelectLanguage" xml:space="preserve">
+    <value>Seleccionar idioma</value>
+  </data>
+  <data name="Language.zh-CN" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Language.en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.ja" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Language.fr" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Language.es" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Language.ru" xml:space="preserve">
+    <value>Русский</value>
+  </data>
+  <data name="Button.Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Button.Save" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="Button.Delete" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="Button.Edit" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="Button.Search" xml:space="preserve">
+    <value>Buscar</value>
+  </data>
+  <data name="Button.Reset" xml:space="preserve">
+    <value>Restablecer</value>
+  </data>
+  <data name="Button.Submit" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="Button.Back" xml:space="preserve">
+    <value>Volver</value>
+  </data>
+  <data name="Button.Add" xml:space="preserve">
+    <value>Agregar</value>
+  </data>
+  <data name="Message.Success" xml:space="preserve">
+    <value>Éxito</value>
+  </data>
+  <data name="Message.Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Message.Warning" xml:space="preserve">
+    <value>Advertencia</value>
+  </data>
+  <data name="Message.Loading" xml:space="preserve">
+    <value>Cargando...</value>
+  </data>
+  <data name="Message.NoData" xml:space="preserve">
+    <value>Sin datos</value>
+  </data>
+  <data name="Message.ConfirmDelete" xml:space="preserve">
+    <value>¿Confirmar eliminación?</value>
+  </data>
+  <data name="Footer.PoweredBy" xml:space="preserve">
+    <value>Potenciado por:</value>
+  </data>
+  <data name="Footer.Copyright" xml:space="preserve">
+    <value>Senparc Network Technology Co., Ltd. Todos los derechos reservados</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.fr.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.fr.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Language.SelectLanguage" xml:space="preserve">
+    <value>Sélectionner la langue</value>
+  </data>
+  <data name="Language.zh-CN" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Language.en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.ja" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Language.fr" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Language.es" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Language.ru" xml:space="preserve">
+    <value>Русский</value>
+  </data>
+  <data name="Button.Confirm" xml:space="preserve">
+    <value>Confirmer</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="Button.Save" xml:space="preserve">
+    <value>Sauvegarder</value>
+  </data>
+  <data name="Button.Delete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="Button.Edit" xml:space="preserve">
+    <value>Modifier</value>
+  </data>
+  <data name="Button.Search" xml:space="preserve">
+    <value>Rechercher</value>
+  </data>
+  <data name="Button.Reset" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="Button.Submit" xml:space="preserve">
+    <value>Soumettre</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="Button.Back" xml:space="preserve">
+    <value>Retour</value>
+  </data>
+  <data name="Button.Add" xml:space="preserve">
+    <value>Ajouter</value>
+  </data>
+  <data name="Message.Success" xml:space="preserve">
+    <value>Succès</value>
+  </data>
+  <data name="Message.Error" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="Message.Warning" xml:space="preserve">
+    <value>Avertissement</value>
+  </data>
+  <data name="Message.Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
+  <data name="Message.NoData" xml:space="preserve">
+    <value>Aucune donnée</value>
+  </data>
+  <data name="Message.ConfirmDelete" xml:space="preserve">
+    <value>Confirmer la suppression?</value>
+  </data>
+  <data name="Footer.PoweredBy" xml:space="preserve">
+    <value>Soutenu par :</value>
+  </data>
+  <data name="Footer.Copyright" xml:space="preserve">
+    <value>Senparc Network Technology Co., Ltd. Tous droits réservés</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.ja.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.ja.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Language.SelectLanguage" xml:space="preserve">
+    <value>言語選択</value>
+  </data>
+  <data name="Language.zh-CN" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Language.en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.ja" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Language.fr" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Language.es" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Language.ru" xml:space="preserve">
+    <value>Русский</value>
+  </data>
+  <data name="Button.Confirm" xml:space="preserve">
+    <value>確認</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="Button.Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Button.Delete" xml:space="preserve">
+    <value>削除</value>
+  </data>
+  <data name="Button.Edit" xml:space="preserve">
+    <value>編集</value>
+  </data>
+  <data name="Button.Search" xml:space="preserve">
+    <value>検索</value>
+  </data>
+  <data name="Button.Reset" xml:space="preserve">
+    <value>リセット</value>
+  </data>
+  <data name="Button.Submit" xml:space="preserve">
+    <value>送信</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="Button.Back" xml:space="preserve">
+    <value>戻る</value>
+  </data>
+  <data name="Button.Add" xml:space="preserve">
+    <value>追加</value>
+  </data>
+  <data name="Message.Success" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="Message.Error" xml:space="preserve">
+    <value>エラー</value>
+  </data>
+  <data name="Message.Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="Message.Loading" xml:space="preserve">
+    <value>読み込み中...</value>
+  </data>
+  <data name="Message.NoData" xml:space="preserve">
+    <value>データなし</value>
+  </data>
+  <data name="Message.ConfirmDelete" xml:space="preserve">
+    <value>削除しますか？</value>
+  </data>
+  <data name="Footer.PoweredBy" xml:space="preserve">
+    <value>テクノロジーサポート：</value>
+  </data>
+  <data name="Footer.Copyright" xml:space="preserve">
+    <value>蘇州盛派ネットワーク科技有限公司 版権所有</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.resx
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <!-- ===== Language Selector ===== -->
+  <data name="Language.SelectLanguage" xml:space="preserve">
+    <value>选择语言</value>
+  </data>
+  <data name="Language.zh-CN" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Language.en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.ja" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Language.fr" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Language.es" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Language.ru" xml:space="preserve">
+    <value>Русский</value>
+  </data>
+
+  <!-- ===== Common Buttons ===== -->
+  <data name="Button.Confirm" xml:space="preserve">
+    <value>确认</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="Button.Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Button.Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="Button.Edit" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="Button.Search" xml:space="preserve">
+    <value>搜索</value>
+  </data>
+  <data name="Button.Reset" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="Button.Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Button.Back" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="Button.Add" xml:space="preserve">
+    <value>添加</value>
+  </data>
+
+  <!-- ===== Common Messages ===== -->
+  <data name="Message.Success" xml:space="preserve">
+    <value>操作成功</value>
+  </data>
+  <data name="Message.Error" xml:space="preserve">
+    <value>操作失败</value>
+  </data>
+  <data name="Message.Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="Message.Loading" xml:space="preserve">
+    <value>加载中...</value>
+  </data>
+  <data name="Message.NoData" xml:space="preserve">
+    <value>暂无数据</value>
+  </data>
+  <data name="Message.ConfirmDelete" xml:space="preserve">
+    <value>确认要删除吗？</value>
+  </data>
+
+  <!-- ===== Footer ===== -->
+  <data name="Footer.PoweredBy" xml:space="preserve">
+    <value>技术支持：</value>
+  </data>
+  <data name="Footer.Copyright" xml:space="preserve">
+    <value>苏州盛派网络科技有限公司 版权所有</value>
+  </data>
+
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.ru.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.ru.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Language.SelectLanguage" xml:space="preserve">
+    <value>Выбор языка</value>
+  </data>
+  <data name="Language.zh-CN" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Language.en" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Language.ja" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Language.fr" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Language.es" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Language.ru" xml:space="preserve">
+    <value>Русский</value>
+  </data>
+  <data name="Button.Confirm" xml:space="preserve">
+    <value>Подтвердить</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="Button.Save" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="Button.Delete" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="Button.Edit" xml:space="preserve">
+    <value>Редактировать</value>
+  </data>
+  <data name="Button.Search" xml:space="preserve">
+    <value>Поиск</value>
+  </data>
+  <data name="Button.Reset" xml:space="preserve">
+    <value>Сбросить</value>
+  </data>
+  <data name="Button.Submit" xml:space="preserve">
+    <value>Отправить</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="Button.Back" xml:space="preserve">
+    <value>Назад</value>
+  </data>
+  <data name="Button.Add" xml:space="preserve">
+    <value>Добавить</value>
+  </data>
+  <data name="Message.Success" xml:space="preserve">
+    <value>Успешно</value>
+  </data>
+  <data name="Message.Error" xml:space="preserve">
+    <value>Ошибка</value>
+  </data>
+  <data name="Message.Warning" xml:space="preserve">
+    <value>Предупреждение</value>
+  </data>
+  <data name="Message.Loading" xml:space="preserve">
+    <value>Загрузка...</value>
+  </data>
+  <data name="Message.NoData" xml:space="preserve">
+    <value>Нет данных</value>
+  </data>
+  <data name="Message.ConfirmDelete" xml:space="preserve">
+    <value>Подтвердить удаление?</value>
+  </data>
+  <data name="Footer.PoweredBy" xml:space="preserve">
+    <value>Разработано:</value>
+  </data>
+  <data name="Footer.Copyright" xml:space="preserve">
+    <value>Suzhou Senparc Network Technology Co., Ltd. Все права защищены</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.zh-CN.resx
+++ b/tools/NcfSimulatedSite/Senparc.Web/Resources/SharedResource.zh-CN.resx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true"><xsd:complexType><xsd:choice maxOccurs="unbounded"><xsd:element name="data"><xsd:complexType><xsd:sequence><xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" /><xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" /></xsd:sequence><xsd:attribute name="name" use="required" type="xsd:string" /><xsd:attribute name="type" type="xsd:string" /><xsd:attribute name="mimetype" type="xsd:string" /></xsd:complexType></xsd:element><xsd:element name="resheader"><xsd:complexType><xsd:sequence><xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" /></xsd:sequence><xsd:attribute name="name" use="required" type="xsd:string" /></xsd:complexType></xsd:element></xsd:choice></xsd:complexType></xsd:element></xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Language.SelectLanguage" xml:space="preserve"><value>选择语言</value></data>
+  <data name="Language.zh-CN" xml:space="preserve"><value>简体中文</value></data>
+  <data name="Language.en" xml:space="preserve"><value>English</value></data>
+  <data name="Language.ja" xml:space="preserve"><value>日本語</value></data>
+  <data name="Language.fr" xml:space="preserve"><value>Français</value></data>
+  <data name="Language.es" xml:space="preserve"><value>Español</value></data>
+  <data name="Language.ru" xml:space="preserve"><value>Русский</value></data>
+  <data name="Button.Confirm" xml:space="preserve"><value>确认</value></data>
+  <data name="Button.Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Button.Save" xml:space="preserve"><value>保存</value></data>
+  <data name="Button.Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="Button.Edit" xml:space="preserve"><value>编辑</value></data>
+  <data name="Button.Search" xml:space="preserve"><value>搜索</value></data>
+  <data name="Button.Reset" xml:space="preserve"><value>重置</value></data>
+  <data name="Button.Submit" xml:space="preserve"><value>提交</value></data>
+  <data name="Button.Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Button.Back" xml:space="preserve"><value>返回</value></data>
+  <data name="Button.Add" xml:space="preserve"><value>添加</value></data>
+  <data name="Message.Success" xml:space="preserve"><value>操作成功</value></data>
+  <data name="Message.Error" xml:space="preserve"><value>操作失败</value></data>
+  <data name="Message.Warning" xml:space="preserve"><value>警告</value></data>
+  <data name="Message.Loading" xml:space="preserve"><value>加载中...</value></data>
+  <data name="Message.NoData" xml:space="preserve"><value>暂无数据</value></data>
+  <data name="Message.ConfirmDelete" xml:space="preserve"><value>确认要删除吗？</value></data>
+  <data name="Footer.PoweredBy" xml:space="preserve"><value>技术支持：</value></data>
+  <data name="Footer.Copyright" xml:space="preserve"><value>苏州盛派网络科技有限公司 版权所有</value></data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Areas/Install/Pages/Index.cshtml
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Areas/Install/Pages/Index.cshtml
@@ -2,14 +2,16 @@
 @model Senparc.Xncf.Instraller.Pages.IndexModel
 @{
     Layout = null;
+    var currentCulture = System.Globalization.CultureInfo.CurrentUICulture.Name;
 }
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Senparc.Xncf.Installer.InstallerResource> IR
 
 <!DOCTYPE html>
-<html>
+<html lang="@currentCulture">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <title>NCF 安装 v @Senparc.Ncf.Core.Config.SiteConfig.VERSION</title>
+    <title>@IR["Install.Title"] v @Senparc.Ncf.Core.Config.SiteConfig.VERSION</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -19,6 +21,17 @@
 </head>
 <body>
     <div id="app">
+        <div style="position: absolute; top: 16px; right: 16px; z-index: 9; background: rgba(255,255,255,.9); border-radius: 6px; padding: 8px 10px;">
+            <label for="ncf-install-lang" style="font-size: 12px; color: #606266; margin-right: 6px;">@IR["Install.LanguageSelect"]</label>
+            <select id="ncf-install-lang" onchange="ncfSwitchLanguage(this.value)">
+                <option value="zh-CN" selected="@(currentCulture == "zh-CN" ? "selected" : null)">简体中文</option>
+                <option value="en" selected="@(currentCulture.StartsWith("en") ? "selected" : null)">English</option>
+                <option value="ja" selected="@(currentCulture.StartsWith("ja") ? "selected" : null)">日本語</option>
+                <option value="fr" selected="@(currentCulture.StartsWith("fr") ? "selected" : null)">Français</option>
+                <option value="es" selected="@(currentCulture.StartsWith("es") ? "selected" : null)">Español</option>
+                <option value="ru" selected="@(currentCulture.StartsWith("ru") ? "selected" : null)">Русский</option>
+            </select>
+        </div>
         @switch (Model.Step)
         {
             case 0:
@@ -28,42 +41,42 @@
                         <div class="logo">
                             <img src="~/images/logo-login-ncf.png" />
                         </div>
-                        <p class="install_notice">检测到系统未初始化，请进行安装！</p>
-                        <p class="install_notice">当前数据库：@Model.MultipleDatabaseType</p>
+                        <p class="install_notice">@IR["Install.NotInit"]</p>
+                        <p class="install_notice">@IR["Install.CurrentDatabase"] @Model.MultipleDatabaseType</p>
                         <p class="install_notice">
-                            多租户状态：@(Model.MultiTenantEnable ? "开启" : "关闭")
+                            @IR["Install.MultiTenantStatus"] @(Model.MultiTenantEnable ? IR["Install.MultiTenantEnabled"] : IR["Install.MultiTenantDisabled"])
                             @if (Model.MultiTenantEnable)
                             {
-                                <text>，规则：@Model.TenantRule</text>
+                                <text>，@IR["Install.MultiTenantRule"] @Model.TenantRule</text>
                             }
                         </p>
                         <form method="post" id="install_main_form">
-                            <a v-on:click="submit" class="option_block" id="btnInstall">立即安装</a>
+                            <a v-on:click="submit" class="option_block" id="btnInstall">@IR["Install.StartButton"]</a>
                         </form>
                         <el-button type="text" v-on:click="toggleInfo" id="btnOptions">
-                            高级选项
+                            @IR["Install.AdvancedOptions"]
                             <i class="el-icon-arrow-right el-icon--right" v-if="!isExpanded"></i>
                             <i class="el-icon-arrow-left el-icon--left" v-if="isExpanded"></i>
                         </el-button>
 
-                        <p class="install_notice red">注意：安装完成后此页面将失效！</p>
+                        <p class="install_notice red">@IR["Install.Warning"]</p>
                     </div>
                     <!-- 展开高级选项时 -->
                     <div class="vertical-line" v-if="isExpanded">
                     </div>
                     <div id="install_start_expand" v-if="isExpanded">
                         <el-form label-width="300px" label-position="top" id="advanced_options">
-                            <el-form-item label="系统名称" :disabled="installStarted" required>
+                            <el-form-item label="@IR["Install.Form.SystemName"]" :disabled="installStarted" required>
                                 <el-input v-model="installOptions.systemName"></el-input>
                             </el-form-item>
-                            <el-form-item label="管理员名称" :disabled="installStarted" required>
+                            <el-form-item label="@IR["Install.Form.AdminUsername"]" :disabled="installStarted" required>
                                 <el-input v-model="installOptions.adminUserName"></el-input>
                             </el-form-item>
-                            <el-form-item label="数据库连接字符串(修改后需重启项目)" :disabled="installStarted" required>
+                            <el-form-item label="@IR["Install.Form.DbConnectionString"]" :disabled="installStarted" required>
                                 <el-input type="textarea" v-model="installOptions.dbConnectionString" :autosize="{ minRows: 2, maxRows: 6}"></el-input>
                             </el-form-item>
-                            <el-form-item label="默认需要的安装模块(安装完成后可以继续安装或卸载)" :disabled="installStarted" required>
-                                <el-select v-model="installOptions.needModelList" multiple placeholder="请选择" style="width: 500px;">
+                            <el-form-item label="@IR["Install.Form.ModuleList"]" :disabled="installStarted" required>
+                                <el-select v-model="installOptions.needModelList" multiple placeholder="@IR["Install.Form.ModulePlaceholder"]" style="width: 500px;">
                                     <el-option v-for="item in optionsModelList"
                                                :key="item.uid"
                                                :label="item.menuName"
@@ -80,24 +93,24 @@
             case 1:
                 <!-- 安装成功时 -->
                 <div id="install_success">
-                    <h2>NeuCharFramework<br />初始化安装成功！</h2>
+                    <h2>@IR["Install.Success.Title"]</h2>
                     <div id="install_success_info">
                         <div>
                             @if (Model.MultiTenantEnable && Model.InstallingTenant)
                             {
                                 <p>
-                                    当前租户已创建，名称：<strong>@Model.TenantInfoDto.Name</strong>，
-                                    匹配规则：<strong>@Model.TenantRule</strong>，
-                                    关键匹配条件：<strong>@Model.TenantInfoDto.TenantKey</strong>
+                                    @IR["Install.Success.TenantCreated"] <strong>@Model.TenantInfoDto.Name</strong>，
+                                    @IR["Install.Success.TenantRule"] <strong>@Model.TenantRule</strong>，
+                                    @IR["Install.Success.TenantKey"] <strong>@Model.TenantInfoDto.TenantKey</strong>
                                 </p>
                             }
                             <p>&nbsp;</p>
-                            <p>请保存好以下信息：</p>
-                            <p>管理员账号：<strong>@Model.AdminUserName</strong></p>
-                            <p>管理员密码：<strong>@Model.AdminPassword</strong></p>
+                            <p>@IR["Install.Success.SaveInfo"]</p>
+                            <p>@IR["Install.Success.AdminAccount"] <strong>@Model.AdminUserName</strong></p>
+                            <p>@IR["Install.Success.AdminPassword"] <strong>@Model.AdminPassword</strong></p>
 
-                            <p>注意：本页面已经失效，请保存好管理员账号及密码，密码无法找回明文！</p>
-                            <p class="center">&gt; <a @*asp-page="/Index" asp-area="Admin"*@ href="/Admin" target="_blank">点击这里登录管理员后台</a> &lt;</p>
+                            <p>@IR["Install.Success.PasswordWarning"]</p>
+                            <p class="center">&gt; <a @*asp-page="/Index" asp-area="Admin"*@ href="/Admin" target="_blank">@IR["Install.Success.LoginLink"]</a> &lt;</p>
                         </div>
                     </div>
                 </div>
@@ -106,13 +119,28 @@
                 break;
         }
         <div id="footer">
-            苏州盛派网络科技有限公司 版权所有
+            @IR["Install.Footer.Copyright"]
         </div>
     </div>
     <!--lib-->
     <script src="~/lib/vue/vue.js"></script>
     <script src="~/lib/element-ui_2.13.2/element.js"></script>
     <script src="~/lib/axios/axios.min.js"></script>
+    <script>
+        window.ncfInstallI18n = {
+            installing: '@IR["Install.StartButton"]',
+            started: '@IR["Install.Warning"]',
+            startConfirm: '@IR["Install.StartButton"]?',
+            startConfirmDetail: '@IR["Install.Warning"]',
+            startedWaiting: '@IR["Install.StartButton"]...',
+            failedPrefix: 'Install failed:'
+        };
+
+        function ncfSwitchLanguage(culture) {
+            var returnUrl = window.location.pathname + window.location.search;
+            window.location.href = '/api/Language/Set?culture=' + encodeURIComponent(culture) + '&returnUrl=' + encodeURIComponent(returnUrl);
+        }
+    </script>
     <!--js-->
     <script src="~/js/Installer/Pages/index.js"></script>
 </body>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.cs
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.cs
@@ -1,0 +1,17 @@
+namespace Senparc.Xncf.Installer
+{
+    /// <summary>
+    /// Marker class for Installer module localization resources.
+    /// Resource files are stored in Resources/InstallerResource.{culture}.resx
+    ///
+    /// Usage in Razor views: @inject IStringLocalizer&lt;InstallerResource&gt; IR
+    /// Usage in code:        IStringLocalizer&lt;InstallerResource&gt; localizer (via DI)
+    ///
+    /// Supported cultures: zh-CN (default), en, ja, fr, es, ru
+    /// To add a new language: copy InstallerResource.en.resx, rename to InstallerResource.{culture}.resx,
+    /// translate the values, and add the culture code to NcfLocalizationOptions.SupportedCultures.
+    /// </summary>
+    public class InstallerResource
+    {
+    }
+}

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.en.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.en.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>NCF Installer</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>System not initialized. Please proceed with installation!</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>Current Database:</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>Multi-tenant Status:</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>Rule:</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>Install Now</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>Advanced Options</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>Warning: This page will expire after installation!</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>System Name</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>Admin Username</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>Database Connection String (restart required after modification)</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>Default modules to install (can be managed after installation)</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>Please select</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>NeuCharFramework Installation Successful!</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>Current tenant created, name:</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>Matching rule:</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>Key condition:</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>Please save the following information:</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>Admin Account:</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>Admin Password:</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>Warning: This page has expired. Please save admin credentials. Plaintext password cannot be retrieved!</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>Click here to login to admin panel</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>Select Language</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>Senparc Network Technology Co., Ltd. All Rights Reserved</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.es.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.es.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>Instalador NCF</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>El sistema no está inicializado. ¡Proceda con la instalación!</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>Base de datos actual:</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>Estado multi-inquilino:</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>Habilitado</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>Deshabilitado</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>Regla:</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>Instalar ahora</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>Opciones avanzadas</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>Advertencia: ¡Esta página expirará después de la instalación!</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>Nombre del sistema</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>Nombre de usuario administrador</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>Cadena de conexión a la BD (reinicio requerido tras modificación)</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>Módulos predeterminados (gestionables tras la instalación)</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>Por favor seleccione</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>¡Instalación de NeuCharFramework exitosa!</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>Locatario actual creado, nombre:</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>Regla de coincidencia:</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>Condición clave:</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>Por favor guarde la siguiente información:</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>Cuenta de administrador:</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>Contraseña de administrador:</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>Advertencia: Página expirada. Guarde las credenciales. ¡La contraseña en texto plano no puede recuperarse!</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>Haga clic aquí para iniciar sesión en el panel de administración</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>Seleccionar idioma</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>Senparc Network Technology Co., Ltd. Todos los derechos reservados</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.fr.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.fr.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>Installateur NCF</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>Le système n'est pas encore initialisé. Veuillez procéder à l'installation !</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>Base de données actuelle :</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>Statut multi-locataire :</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>Règle :</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>Installer maintenant</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>Options avancées</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>Attention : cette page sera expirée après l'installation !</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>Nom du système</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>Nom d'utilisateur administrateur</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>Chaîne de connexion (redémarrage requis après modification)</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>Modules par défaut à installer (gérables après installation)</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>Veuillez choisir</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>Installation de NeuCharFramework réussie !</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>Locataire actuel créé, nom :</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>Règle de correspondance :</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>Condition principale :</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>Veuillez sauvegarder les informations suivantes :</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>Compte administrateur :</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>Mot de passe administrateur :</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>Attention : Cette page a expiré. Sauvegardez les identifiants. Le mot de passe en clair ne peut pas être récupéré !</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>Cliquez ici pour vous connecter au panneau d'administration</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>Sélectionner la langue</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>Senparc Network Technology Co., Ltd. Tous droits réservés</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.ja.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.ja.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>NCF インストーラー</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>システムが初期化されていません。インストールを開始してください！</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>現在のデータベース：</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>マルチテナント状態：</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>有効</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>無効</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>ルール：</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>今すぐインストール</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>詳細オプション</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>注意：インストール後、このページは無効になります！</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>システム名</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>管理者ユーザー名</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>データベース接続文字列（変更後はプロジェクトの再起動が必要）</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>デフォルトでインストールするモジュール（インストール後に管理可能）</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>選択してください</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>NeuCharFramework のインストールが成功しました！</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>現在のテナントが作成されました、名前：</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>照合ルール：</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>主なマッチング条件：</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>以下の情報を保存してください：</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>管理者アカウント：</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>管理者パスワード：</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>注意：このページは無効になりました。認証情報を保存してください。平文パスワードは取得できません！</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>ここをクリックして管理パネルにログイン</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>言語選択</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>蘇州盛派ネットワーク科技有限公司 版権所有</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>NCF 安装程序</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>检测到系统未初始化，请进行安装！</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>当前数据库：</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>多租户状态：</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>开启</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>规则：</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>立即安装</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>高级选项</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>注意：安装完成后此页面将失效！</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>系统名称</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>管理员名称</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>数据库连接字符串(修改后需重启项目)</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>默认需要的安装模块(安装完成后可以继续安装或卸载)</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>请选择</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>NeuCharFramework 初始化安装成功！</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>当前租户已创建，名称：</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>匹配规则：</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>关键匹配条件：</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>请保存好以下信息：</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>管理员账号：</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>管理员密码：</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>注意：本页面已经失效，请保存好管理员账号及密码，密码无法找回明文！</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>点击这里登录管理员后台</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>选择语言</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>苏州盛派网络科技有限公司 版权所有</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.ru.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.ru.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>Установщик NCF</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>Система не инициализирована. Выполните установку!</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>Текущая база данных:</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>Статус мультитенантности:</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>Включено</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>Отключено</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>Правило:</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>Установить сейчас</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>Расширенные настройки</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>Предупреждение: после установки эта страница станет недействительной!</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>Название системы</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>Имя пользователя администратора</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>Строка подключения к БД (после изменения требуется перезапуск)</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>Модули для установки по умолчанию (можно изменить после установки)</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>Пожалуйста, выберите</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>Установка NeuCharFramework выполнена успешно!</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>Текущий тенант создан, имя:</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>Правило сопоставления:</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>Ключевое условие:</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>Пожалуйста, сохраните следующую информацию:</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>Учётная запись администратора:</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>Пароль администратора:</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>Предупреждение: страница недействительна. Сохраните учётные данные. Восстановить пароль в открытом виде невозможно!</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>Нажмите здесь для входа в панель администратора</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>Выбор языка</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>Suzhou Senparc Network Technology Co., Ltd. Все права защищены</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.zh-CN.resx
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/Resources/InstallerResource.zh-CN.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Install.Title" xml:space="preserve">
+    <value>NCF 安装程序</value>
+  </data>
+  <data name="Install.NotInit" xml:space="preserve">
+    <value>检测到系统未初始化，请进行安装！</value>
+  </data>
+  <data name="Install.CurrentDatabase" xml:space="preserve">
+    <value>当前数据库：</value>
+  </data>
+  <data name="Install.MultiTenantStatus" xml:space="preserve">
+    <value>多租户状态：</value>
+  </data>
+  <data name="Install.MultiTenantEnabled" xml:space="preserve">
+    <value>开启</value>
+  </data>
+  <data name="Install.MultiTenantDisabled" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Install.MultiTenantRule" xml:space="preserve">
+    <value>规则：</value>
+  </data>
+  <data name="Install.StartButton" xml:space="preserve">
+    <value>立即安装</value>
+  </data>
+  <data name="Install.AdvancedOptions" xml:space="preserve">
+    <value>高级选项</value>
+  </data>
+  <data name="Install.Warning" xml:space="preserve">
+    <value>注意：安装完成后此页面将失效！</value>
+  </data>
+  <data name="Install.Form.SystemName" xml:space="preserve">
+    <value>系统名称</value>
+  </data>
+  <data name="Install.Form.AdminUsername" xml:space="preserve">
+    <value>管理员名称</value>
+  </data>
+  <data name="Install.Form.DbConnectionString" xml:space="preserve">
+    <value>数据库连接字符串(修改后需重启项目)</value>
+  </data>
+  <data name="Install.Form.ModuleList" xml:space="preserve">
+    <value>默认需要的安装模块(安装完成后可以继续安装或卸载)</value>
+  </data>
+  <data name="Install.Form.ModulePlaceholder" xml:space="preserve">
+    <value>请选择</value>
+  </data>
+  <data name="Install.Success.Title" xml:space="preserve">
+    <value>NeuCharFramework 初始化安装成功！</value>
+  </data>
+  <data name="Install.Success.TenantCreated" xml:space="preserve">
+    <value>当前租户已创建，名称：</value>
+  </data>
+  <data name="Install.Success.TenantRule" xml:space="preserve">
+    <value>匹配规则：</value>
+  </data>
+  <data name="Install.Success.TenantKey" xml:space="preserve">
+    <value>关键匹配条件：</value>
+  </data>
+  <data name="Install.Success.SaveInfo" xml:space="preserve">
+    <value>请保存好以下信息：</value>
+  </data>
+  <data name="Install.Success.AdminAccount" xml:space="preserve">
+    <value>管理员账号：</value>
+  </data>
+  <data name="Install.Success.AdminPassword" xml:space="preserve">
+    <value>管理员密码：</value>
+  </data>
+  <data name="Install.Success.PasswordWarning" xml:space="preserve">
+    <value>注意：本页面已经失效，请保存好管理员账号及密码，密码无法找回明文！</value>
+  </data>
+  <data name="Install.Success.LoginLink" xml:space="preserve">
+    <value>点击这里登录管理员后台</value>
+  </data>
+  <data name="Install.LanguageSelect" xml:space="preserve">
+    <value>选择语言</value>
+  </data>
+  <data name="Install.Footer.Copyright" xml:space="preserve">
+    <value>苏州盛派网络科技有限公司 版权所有</value>
+  </data>
+</root>

--- a/tools/NcfSimulatedSite/Senparc.Xncf.Installer/wwwroot/js/Installer/Pages/index.js
+++ b/tools/NcfSimulatedSite/Senparc.Xncf.Installer/wwwroot/js/Installer/Pages/index.js
@@ -31,24 +31,26 @@ var app = new Vue({
         },
         submit() {
             if (this.installStarted) {
-                alert('安装已经在进行中，请等待');
+                alert((window.ncfInstallI18n && window.ncfInstallI18n.started) || 'Installation is already running, please wait.');
                 return false;
             }
 
-            if (!confirm('确定要开始安装吗？安装完成后此页面将失效！')) {
+            var confirmText = ((window.ncfInstallI18n && window.ncfInstallI18n.startConfirm) || 'Start installation?') + '\n' +
+                ((window.ncfInstallI18n && window.ncfInstallI18n.startConfirmDetail) || 'This page will expire after installation.');
+            if (!confirm(confirmText)) {
                 return false;
             }
 
             this.installStarted = true;
 
             document.getElementById('btnInstall').setAttribute('disabled', true);
-            document.getElementById('btnInstall').innerHTML = '安装已启动，请稍后……';
+            document.getElementById('btnInstall').innerHTML = (window.ncfInstallI18n && window.ncfInstallI18n.startedWaiting) || 'Installation started, please wait...';
 
             axios.post("/Install/Index", this.installOptions, {
             }).then(res => {
                 document.getElementById('app').innerHTML = res.data;
             }).catch(error => {
-                document.getElementById('app').innerHTML = '安装失败:' + error;
+                document.getElementById('app').innerHTML = ((window.ncfInstallI18n && window.ncfInstallI18n.failedPrefix) || 'Install failed:') + error;
             });
             return true;
         }


### PR DESCRIPTION
- Created English (en), Spanish (es), French (fr), Japanese (ja), Russian (ru), and Simplified Chinese (zh-CN) resource files for the NCF Installer.
- Each resource file includes localized strings for installation prompts, warnings, and success messages.